### PR TITLE
回退下载链接更改

### DIFF
--- a/src/main/java/i18nupdatemod/core/AssetConfig.java
+++ b/src/main/java/i18nupdatemod/core/AssetConfig.java
@@ -13,7 +13,7 @@ public class AssetConfig {
     /**
      * <a href="https://github.com/zkitefly/TranslationPackConvert">zkitefly/TranslationPackConvert</a>
      */
-    private static final String CONVERT_ASSET_ROOT = "https://gitcode.net/chearlai/translationpackmirror/-/raw/main/files/";
+    private static final String CONVERT_ASSET_ROOT = "https://gitcode.net/chearlai/translationpackconvert/-/raw/main/files/";
 
     public enum Type {
         FILE_NAME,


### PR DESCRIPTION
资源包转换的下载链接应该是 `https://gitcode.net/chearlai/translationpackconvert`，但在 #1 中将链接错误的使用了镜像下载源的链接