### PR TITLE
1.21 支持原生资源包 + 发版

### DIFF
--- a/src/main/resources/i18nMetaData.json
+++ b/src/main/resources/i18nMetaData.json
@@ -124,9 +124,18 @@
       "gameVersions": "[1.21,1.21.1]",
       "packFormat": 34,
       "convertFrom": [
+        "1.21",
         "1.20",
-        "1.19",
-        "1.18"
+        "1.19"
+      ]
+    },
+    {
+      "gameVersions": "[1.21.2,1.21.2]",
+      "packFormat": 42,
+      "convertFrom": [
+        "1.21",
+        "1.20",
+        "1.19"
       ]
     }
   ],
@@ -184,6 +193,18 @@
       "loader": "Fabric",
       "filename": "Minecraft-Mod-Language-Modpack-1-20-Fabric.zip",
       "md5Filename": "1.20-fabric.md5"
+    },
+    {
+      "targetVersion": "1.21",
+      "loader": "Forge",
+      "filename": "Minecraft-Mod-Language-Modpack-1-21.zip",
+      "md5Filename": "1.21.md5"
+    },
+    {
+      "targetVersion": "1.21",
+      "loader": "Fabric",
+      "filename": "Minecraft-Mod-Language-Modpack-1-21-Fabric.zip",
+      "md5Filename": "1.21-fabric.md5"
     }
   ]
 }


### PR DESCRIPTION
应该是这么改吧，建议瞄准1.21.2发布（大概率本周内）
个人意见是先推出一版模组，优化只有瞄准1.21.3或1.22了
需要考虑的：合并策略怎样