### PR TITLE
fix: set neoforge as one of the loaders on Modrinth

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ modrinth {
     versionType.set("release")
     uploadFile.set(tasks["shadowJar"])
     gameVersions.set(supportMinecraftVersions)
-    loaders.set(listOf("fabric", "forge", "quilt"))
+    loaders.set(listOf("fabric", "forge", "neoforge", "quilt"))
     syncBodyFrom.set(rootProject.file("README.md").readText())
     changelog.set(System.getenv("CHANGE_LOG"))
 }


### PR DESCRIPTION
Closes #27.

*Versions 3.5.2~3.6.0 on Modrinth need to be adjusted manually.*

*Please tell me if I am wrong.*