### PR TITLE
feat: 启动游戏5秒内没下载好资源包则不再等待下载

### DIFF
--- a/src/main/java/i18nupdatemod/I18nUpdateMod.java
+++ b/src/main/java/i18nupdatemod/I18nUpdateMod.java
@@ -18,10 +18,13 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class I18nUpdateMod {
+    private static final int DOWNLOAD_WAIT_SECONDS = 10;
     public static final String MOD_ID = "i18nupdatemod";
     public static String MOD_VERSION;
 
@@ -55,37 +58,72 @@ public class I18nUpdateMod {
 
         int minecraftMajorVersion = Integer.parseInt(minecraftVersion.split("\\.")[1]);
 
-        try {
+        CompletableFuture<DownloadTaskResult> downloadTask = CompletableFuture.supplyAsync(() -> {
             //Get asset
             GameAssetDetail assets = I18nConfig.getAssetDetail(minecraftVersion, loader);
+            if (assets.downloads.isEmpty()) {
+                Log.info("No resource pack found for " + minecraftVersion + " with loader " + loader);
+                return new DownloadTaskResult(true, assets, "", null);
+            }
 
             //Update resource pack
             List<ResourcePack> languagePacks = new ArrayList<>();
+            List<CompletableFuture<Void>> downloadTasks = new ArrayList<>();
             boolean convertNotNeed = assets.downloads.size() == 1 && assets.downloads.get(0).targetVersion.equals(minecraftVersion);
             String applyFileName = assets.downloads.get(0).fileName;
             for (GameAssetDetail.AssetDownloadDetail it : assets.downloads) {
                 FileUtil.setTemporaryDirPath(Paths.get(localStorage, "." + MOD_ID, it.targetVersion));
                 ResourcePack languagePack = new ResourcePack(it.fileName, convertNotNeed);
-                languagePack.checkUpdate(it.fileUrl, it.md5Url);
+                downloadTasks.add(CompletableFuture.runAsync(() -> {
+                    try {
+                        languagePack.checkUpdate(it.fileUrl, it.md5Url);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
                 languagePacks.add(languagePack);
             }
 
-            //Convert resourcepack
-            if (!convertNotNeed) {
-                FileUtil.setTemporaryDirPath(Paths.get(localStorage, "." + MOD_ID, minecraftVersion));
-                applyFileName = assets.covertFileName;
-                ResourcePackConverter converter = new ResourcePackConverter(languagePacks, applyFileName);
-                converter.convert(assets.covertPackFormat, getResourcePackDescription(assets.downloads));
+            // Wait for all download tasks to complete
+            CompletableFuture.allOf(downloadTasks.toArray(new CompletableFuture[0])).join();
+            return new DownloadTaskResult(convertNotNeed, assets, applyFileName, languagePacks);
+        });
+
+        // Convert and apply resource pack
+        Consumer<DownloadTaskResult> convertAndApply = (result) -> {
+            if (result.assets.downloads.isEmpty()) {
+                return;
             }
 
-            //Apply resource pack
-            GameConfig config = new GameConfig(minecraftPath.resolve("options.txt"));
-            config.addResourcePack("Minecraft-Mod-Language-Modpack",
-                    (minecraftMajorVersion <= 12 ? "" : "file/") + applyFileName);
-            config.writeToFile();
-        } catch (Exception e) {
-            Log.warning(String.format("Failed to update resource pack: %s", e));
-//            e.printStackTrace();
+            try {
+                //Convert resourcepack
+                if (!result.convertNotNeed) {
+                    FileUtil.setTemporaryDirPath(Paths.get(localStorage, "." + MOD_ID, minecraftVersion));
+                    result.applyFileName = result.assets.covertFileName;
+                    ResourcePackConverter converter = new ResourcePackConverter(result.languagePacks, result.applyFileName);
+                    converter.convert(result.assets.covertPackFormat, getResourcePackDescription(result.assets.downloads));
+                }
+
+                //Apply resource pack
+                GameConfig config = new GameConfig(minecraftPath.resolve("options.txt"));
+                config.addResourcePack("Minecraft-Mod-Language-Modpack",
+                        (minecraftMajorVersion <= 12 ? "" : "file/") + result.applyFileName);
+                config.writeToFile();
+            } catch (Exception e) {
+                Log.warning(String.format("Failed to convert and apply resource pack: %s", e));
+                //e.printStackTrace();
+            }
+        };
+
+        // Handle the download task result, if it completes within the timeout, apply the resource pack
+        try {
+            DownloadTaskResult r = downloadTask.get(DOWNLOAD_WAIT_SECONDS, TimeUnit.SECONDS); // Wait for the download task to complete
+            convertAndApply.accept(r);
+        } catch (TimeoutException ex) {
+            downloadTask.thenAccept(convertAndApply);
+            Log.info("Resource pack download take too long, will apply it when download finished.");
+        } catch (ExecutionException | InterruptedException ex) {
+            Log.warning(String.format("Failed to download resource pack: %s", ex.getCause()));
         }
     }
 
@@ -120,5 +158,20 @@ public class I18nUpdateMod {
         return Stream.of(localAppData, macAppSupport).filter(
                 Objects::nonNull
         ).findFirst().orElse(xdgDataHome);
+    }
+
+    private static class DownloadTaskResult
+    {
+        public boolean convertNotNeed;
+        public GameAssetDetail assets;
+        public String applyFileName;
+        public List<ResourcePack> languagePacks;
+
+        public DownloadTaskResult(boolean convertNotNeed, GameAssetDetail assets, String applyFileName, List<ResourcePack> languagePacks) {
+            this.convertNotNeed = convertNotNeed;
+            this.assets = assets;
+            this.applyFileName = applyFileName;
+            this.languagePacks = languagePacks;
+        }
     }
 }


### PR DESCRIPTION
之前把下载任务放在主线程，现在把下载任务放在别的线程
主线程最多等待5秒下载，若5秒内没下载完则不再阻塞主线程，把合并和应用资源包放在下载完毕后的另一个线程执行

bug：这样做的话可能不会让游戏自动应用资源包，因为可能下载完之后options.txt已经加载完了