### PR TITLE
feat: Support download from mirrors

### DIFF
--- a/src/main/java/i18nupdatemod/core/I18nConfig.java
+++ b/src/main/java/i18nupdatemod/core/I18nConfig.java
@@ -28,7 +28,6 @@ public class I18nConfig {
     private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
     private static final Gson GSON = new Gson();
     private static I18nMetaData i18nMetaData;
-    private static final Map<String, String> serverGitIndex = new HashMap<>();
 
     static {
         init();
@@ -43,24 +42,6 @@ public class I18nConfig {
             }
         } catch (Exception e) {
             Log.warning("Error getting index: " + e);
-        }
-        // Update with i18nMetaData.json and GitHub Packer
-        String[][] mappings = {
-                {"Minecraft-Mod-Language-Modpack.zip", "Minecraft-Mod-Language-Package-1.12.2.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-16.zip", "Minecraft-Mod-Language-Package-1.16.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-16-Fabric.zip", "Minecraft-Mod-Language-Package-1.16-fabric.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-18.zip", "Minecraft-Mod-Language-Package-1.18.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-18-Fabric.zip", "Minecraft-Mod-Language-Package-1.18-fabric.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-19.zip", "Minecraft-Mod-Language-Package-1.19.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-19-Fabric.zip", "Minecraft-Mod-Language-Package-1.19-fabric.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-20.zip", "Minecraft-Mod-Language-Package-1.20.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-20-Fabric.zip", "Minecraft-Mod-Language-Package-1.20-fabric.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-21.zip", "Minecraft-Mod-Language-Package-1.21.zip"},
-                {"Minecraft-Mod-Language-Modpack-1-21-Fabric.zip", "Minecraft-Mod-Language-Package-1.21-fabric.zip"}
-        };
-
-        for (String[] mapping : mappings) {
-            serverGitIndex.put(mapping[0], mapping[1]);
         }
     }
 
@@ -131,7 +112,7 @@ public class I18nConfig {
             return convert.convertFrom.stream().map(it -> getAssetMetaData(it, loader)).map(it -> {
                 GameAssetDetail.AssetDownloadDetail adi = new GameAssetDetail.AssetDownloadDetail();
                 adi.fileName = it.filename;
-                adi.fileUrl = asset_root + serverGitIndex.get(it.filename);
+                adi.fileUrl = asset_root + it.filename;
                 adi.md5Url = asset_root + it.md5Filename;
                 adi.targetVersion = it.targetVersion;
                 return adi;

--- a/src/main/java/i18nupdatemod/core/I18nConfig.java
+++ b/src/main/java/i18nupdatemod/core/I18nConfig.java
@@ -25,7 +25,7 @@ public class I18nConfig {
     /**
      * <a href="https://github.com/CFPAOrg/Minecraft-Mod-Language-Package">CFPAOrg/Minecraft-Mod-Language-Package</a>
      */
-    private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
+    private static final String CFPA_assetRoot = "http://downloader1.meitangdehulu.com:22943/";
     private static final Gson GSON = new Gson();
     private static I18nMetaData i18nMetaData;
 
@@ -65,13 +65,13 @@ public class I18nConfig {
         GameMetaData convert = getGameMetaData(minecraftVersion);
         GameAssetDetail ret = new GameAssetDetail();
 
-        String asset_root = getFastestUrl();
-        Log.debug("Using asset root: " + asset_root);
+        String assetRoot = getFastestUrl();
+        Log.debug("Using asset root: " + assetRoot);
 
-        if (asset_root.contains("github")) {
+        if (assetRoot.contains("github")) {
             ret.downloads = createDownloadDetailsFromGit(convert, loader);
         } else {
-            ret.downloads = createDownloadDetails(convert, loader, asset_root);
+            ret.downloads = createDownloadDetails(convert, loader, assetRoot);
         }
 
         ret.covertPackFormat = convert.packFormat;
@@ -80,12 +80,12 @@ public class I18nConfig {
         return ret;
     }
 
-    private static List<GameAssetDetail.AssetDownloadDetail> createDownloadDetails(GameMetaData convert, String loader, String asset_root) {
+    private static List<GameAssetDetail.AssetDownloadDetail> createDownloadDetails(GameMetaData convert, String loader, String assetRoot) {
         return convert.convertFrom.stream().map(it -> getAssetMetaData(it, loader)).map(it -> {
             GameAssetDetail.AssetDownloadDetail adi = new GameAssetDetail.AssetDownloadDetail();
             adi.fileName = it.filename;
-            adi.fileUrl = asset_root + it.filename;
-            adi.md5Url = asset_root + it.md5Filename;
+            adi.fileUrl = assetRoot + it.filename;
+            adi.md5Url = assetRoot + it.md5Filename;
             adi.targetVersion = it.targetVersion;
             return adi;
         }).collect(Collectors.toList());
@@ -107,18 +107,18 @@ public class I18nConfig {
                 Log.debug(index.toString());
                 throw new Exception();
             }
-            String asset_root = "https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/releases/download/" + releaseTag + "/";
+            String assetRoot = "https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/releases/download/" + releaseTag + "/";
 
             return convert.convertFrom.stream().map(it -> getAssetMetaData(it, loader)).map(it -> {
                 GameAssetDetail.AssetDownloadDetail adi = new GameAssetDetail.AssetDownloadDetail();
                 adi.fileName = it.filename;
-                adi.fileUrl = asset_root + it.filename;
-                adi.md5Url = asset_root + it.md5Filename;
+                adi.fileUrl = assetRoot + it.filename;
+                adi.md5Url = assetRoot + it.md5Filename;
                 adi.targetVersion = it.targetVersion;
                 return adi;
             }).collect(Collectors.toList());
         } catch (Exception ignore) {
-            return createDownloadDetails(convert, loader, CFPA_ASSET_ROOT);
+            return createDownloadDetails(convert, loader, CFPA_assetRoot);
         }
     }
 }

--- a/src/main/java/i18nupdatemod/core/I18nConfig.java
+++ b/src/main/java/i18nupdatemod/core/I18nConfig.java
@@ -11,9 +11,6 @@ import i18nupdatemod.util.VersionRange;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -25,7 +22,7 @@ public class I18nConfig {
     /**
      * <a href="https://github.com/CFPAOrg/Minecraft-Mod-Language-Package">CFPAOrg/Minecraft-Mod-Language-Package</a>
      */
-    private static final String CFPA_ASSET_ROOT  = "http://downloader1.meitangdehulu.com:22943/";
+    private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
     private static final Gson GSON = new Gson();
     private static I18nMetaData i18nMetaData;
 
@@ -68,7 +65,7 @@ public class I18nConfig {
         String assetRoot = getFastestUrl();
         Log.debug("Using asset root: " + assetRoot);
 
-        if (assetRoot.contains("github")) {
+        if (assetRoot.equals("https://raw.githubusercontent.com/")) {
             ret.downloads = createDownloadDetailsFromGit(convert, loader);
         } else {
             ret.downloads = createDownloadDetails(convert, loader, assetRoot);
@@ -97,9 +94,9 @@ public class I18nConfig {
             String releaseTag;
             String version = convert.convertFrom.get(0);
 
-            if(loader.toLowerCase().contains("fabric")){
+            if (loader.toLowerCase().contains("fabric")) {
                 releaseTag = index.get(version + "-fabric");
-            }else{
+            } else {
                 releaseTag = index.get(version);
             }
             if (releaseTag == null) {
@@ -118,7 +115,7 @@ public class I18nConfig {
                 return adi;
             }).collect(Collectors.toList());
         } catch (Exception ignore) {
-            return createDownloadDetails(convert, loader, CFPA_ASSET_ROOT );
+            return createDownloadDetails(convert, loader, CFPA_ASSET_ROOT);
         }
     }
 }

--- a/src/main/java/i18nupdatemod/core/I18nConfig.java
+++ b/src/main/java/i18nupdatemod/core/I18nConfig.java
@@ -25,7 +25,7 @@ public class I18nConfig {
     /**
      * <a href="https://github.com/CFPAOrg/Minecraft-Mod-Language-Package">CFPAOrg/Minecraft-Mod-Language-Package</a>
      */
-    private static final String CFPA_assetRoot = "http://downloader1.meitangdehulu.com:22943/";
+    private static final String CFPA_ASSET_ROOT  = "http://downloader1.meitangdehulu.com:22943/";
     private static final Gson GSON = new Gson();
     private static I18nMetaData i18nMetaData;
 
@@ -118,7 +118,7 @@ public class I18nConfig {
                 return adi;
             }).collect(Collectors.toList());
         } catch (Exception ignore) {
-            return createDownloadDetails(convert, loader, CFPA_assetRoot);
+            return createDownloadDetails(convert, loader, CFPA_ASSET_ROOT );
         }
     }
 }

--- a/src/main/java/i18nupdatemod/core/I18nConfig.java
+++ b/src/main/java/i18nupdatemod/core/I18nConfig.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ public class I18nConfig {
     private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
     private static final Gson GSON = new Gson();
     private static I18nMetaData i18nMetaData;
+    private static final Map<String, String> serverGitIndex = new HashMap<>();
 
     static {
         init();
@@ -41,6 +43,24 @@ public class I18nConfig {
             }
         } catch (Exception e) {
             Log.warning("Error getting index: " + e);
+        }
+        // Update with i18nMetaData.json and GitHub Packer
+        String[][] mappings = {
+                {"Minecraft-Mod-Language-Modpack.zip", "Minecraft-Mod-Language-Package-1.12.2.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-16.zip", "Minecraft-Mod-Language-Package-1.16.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-16-Fabric.zip", "Minecraft-Mod-Language-Package-1.16-fabric.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-18.zip", "Minecraft-Mod-Language-Package-1.18.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-18-Fabric.zip", "Minecraft-Mod-Language-Package-1.18-fabric.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-19.zip", "Minecraft-Mod-Language-Package-1.19.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-19-Fabric.zip", "Minecraft-Mod-Language-Package-1.19-fabric.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-20.zip", "Minecraft-Mod-Language-Package-1.20.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-20-Fabric.zip", "Minecraft-Mod-Language-Package-1.20-fabric.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-21.zip", "Minecraft-Mod-Language-Package-1.21.zip"},
+                {"Minecraft-Mod-Language-Modpack-1-21-Fabric.zip", "Minecraft-Mod-Language-Package-1.21-fabric.zip"}
+        };
+
+        for (String[] mapping : mappings) {
+            serverGitIndex.put(mapping[0], mapping[1]);
         }
     }
 
@@ -94,7 +114,7 @@ public class I18nConfig {
         try {
             Map<String, String> index = getGitIndex();
             String releaseTag;
-            String version = convert.gameVersions.substring(1,5);
+            String version = convert.convertFrom.get(0);
 
             if(loader.toLowerCase().contains("fabric")){
                 releaseTag = index.get(version + "-fabric");
@@ -111,7 +131,7 @@ public class I18nConfig {
             return convert.convertFrom.stream().map(it -> getAssetMetaData(it, loader)).map(it -> {
                 GameAssetDetail.AssetDownloadDetail adi = new GameAssetDetail.AssetDownloadDetail();
                 adi.fileName = it.filename;
-                adi.fileUrl = (asset_root + it.filename).replace("Minecraft-Mod-Language-Modpack-1-","Minecraft-Mod-Language-Package-1.");
+                adi.fileUrl = asset_root + serverGitIndex.get(it.filename);
                 adi.md5Url = asset_root + it.md5Filename;
                 adi.targetVersion = it.targetVersion;
                 return adi;

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -1,16 +1,39 @@
 package i18nupdatemod.util;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
 
 public class AssetUtil {
+    private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
+    private static final List<String> MIRRORS;
+
+    static {
+        // 镜像地址可以改成服务器下发
+        MIRRORS = new ArrayList<>();
+        // MIRRORS.add("http://localhost:8080/");
+        MIRRORS.add("https://raw.githubusercontent.com/");
+    }
+
     public static void download(String url, Path localFile) throws IOException, URISyntaxException {
         Log.info("Downloading: %s -> %s", url, localFile);
         FileUtils.copyURLToFile(new URI(url).toURL(), localFile.toFile(),
@@ -20,5 +43,85 @@ public class AssetUtil {
 
     public static String getString(String url) throws IOException, URISyntaxException {
         return IOUtils.toString(new URI(url).toURL(), StandardCharsets.UTF_8);
+    }
+
+    public static String getFastestUrl() {
+        List<String> urls = new ArrayList<>(MIRRORS);
+        urls.add(CFPA_ASSET_ROOT);
+
+        ExecutorService executor = Executors.newFixedThreadPool(Math.max(urls.size(), 10));
+        try {
+            List<CompletableFuture<String>> futures = new ArrayList<>();
+            for (String url : urls) {
+                CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return testUrlConnection(url);
+                    } catch (IOException e) {
+                        return null; // 表示失败
+                    }
+                }, executor);
+                futures.add(future);
+            }
+
+            // 阻塞等待最快完成且成功的任务
+            String fastest = null;
+            while (!futures.isEmpty()) {
+                CompletableFuture<Object> first = CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0]));
+                fastest = (String) first.join();
+
+                // 移除已完成的 future
+                futures.removeIf(CompletableFuture::isDone);
+
+                if (fastest != null) {
+                    // 成功，取消其他任务
+                    for (CompletableFuture<String> f : futures) {
+                        f.cancel(true);
+                    }
+                    Log.info("Using fastest url: %s", fastest);
+                    return fastest;
+                }
+            }
+
+            // 全部失败，返回默认 URL
+            Log.info("All urls are unreachable, using CFPA_ASSET_ROOT");
+            return CFPA_ASSET_ROOT;
+
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static String testUrlConnection(String url) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        conn.setRequestMethod("HEAD");
+        conn.setConnectTimeout(3000);
+        conn.setReadTimeout(5000);
+        conn.connect();
+        int code = conn.getResponseCode();
+        if (code >= 200 && code < 300) {
+            return url;
+        }
+        Log.debug("URL unreachable: %s, code: %d", url, code);
+        throw new IOException("URL unreachable: " + url);
+    }
+
+    @NotNull
+    public static Map<String,String> getGitIndex(){
+        try{
+            URL index_url = new URL("https://raw.githubusercontent.com/CFPAOrg/Minecraft-Mod-Language-Package/refs/heads/main/version-index.json");
+            HttpURLConnection httpConn = (HttpURLConnection) index_url.openConnection();
+            httpConn.setRequestMethod("GET");
+            httpConn.setConnectTimeout(5000);
+            httpConn.setReadTimeout(5000);
+
+            try (InputStreamReader reader = new InputStreamReader(httpConn.getInputStream())) {
+                Type mapType = new TypeToken<Map<String, String>>(){}.getType();
+                return new Gson().fromJson(reader, mapType);
+            } finally {
+                httpConn.disconnect();
+            }
+        } catch (Exception ignore) {
+            return new HashMap<>();
+        }
     }
 }

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -33,7 +33,7 @@ public class AssetUtil {
         // MIRRORS.add("http://localhost:8080/");
         MIRRORS.add("https://raw.githubusercontent.com/");
         // 此镜像源维护者：502y
-        MIRRORS.add("http://203.135.99.76:30002/");
+        MIRRORS.add("http://8.137.167.65:64684/");
     }
 
     public static void download(String url, Path localFile) throws IOException, URISyntaxException {

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -28,7 +28,6 @@ public class AssetUtil {
     static {
         // 镜像地址可以改成服务器下发
         MIRRORS = new ArrayList<>();
-        // MIRRORS.add("http://localhost:8080/");
         MIRRORS.add("https://raw.githubusercontent.com/");
         // 此镜像源维护者：502y
         MIRRORS.add("http://8.137.167.65:64684/");

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -6,9 +6,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
@@ -108,8 +106,8 @@ public class AssetUtil {
     }
 
     @NotNull
-    public static Map<String,String> getGitIndex(){
-        try{
+    public static Map<String, String> getGitIndex() {
+        try {
             URL index_url = new URL("https://raw.githubusercontent.com/CFPAOrg/Minecraft-Mod-Language-Package/refs/heads/index/version-index.json");
             HttpURLConnection httpConn = (HttpURLConnection) index_url.openConnection();
             httpConn.setRequestMethod("GET");
@@ -117,7 +115,8 @@ public class AssetUtil {
             httpConn.setReadTimeout(5000);
 
             try (InputStreamReader reader = new InputStreamReader(httpConn.getInputStream())) {
-                Type mapType = new TypeToken<Map<String, String>>(){}.getType();
+                Type mapType = new TypeToken<Map<String, String>>() {
+                }.getType();
                 return new Gson().fromJson(reader, mapType);
             } finally {
                 httpConn.disconnect();

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -32,6 +32,8 @@ public class AssetUtil {
         MIRRORS = new ArrayList<>();
         // MIRRORS.add("http://localhost:8080/");
         MIRRORS.add("https://raw.githubusercontent.com/");
+        // 此镜像源维护者：502y
+        MIRRORS.add("http://203.135.99.76:30002/");
     }
 
     public static void download(String url, Path localFile) throws IOException, URISyntaxException {

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -110,7 +110,7 @@ public class AssetUtil {
     @NotNull
     public static Map<String,String> getGitIndex(){
         try{
-            URL index_url = new URL("https://raw.githubusercontent.com/CFPAOrg/Minecraft-Mod-Language-Package/refs/heads/main/version-index.json");
+            URL index_url = new URL("https://raw.githubusercontent.com/CFPAOrg/Minecraft-Mod-Language-Package/refs/heads/index/version-index.json");
             HttpURLConnection httpConn = (HttpURLConnection) index_url.openConnection();
             httpConn.setRequestMethod("GET");
             httpConn.setConnectTimeout(5000);


### PR DESCRIPTION
**此PR必须在 https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/pull/5523 后才能合并，否则会导致GitHub访问性较好的用户无法正常使用。**

计划是这样的……

1. i18n在下载前对所有下载源进行连接性检查，并将相应最快的那个作为本次的下载源
2. 如果用户到Github响应最快，从GitHub下载资源包
3. 通过索引文件确认每个版本最新的release
4. 根据每个Release Tag下载资源包

顺便支持了对葫芦服务器的镜像。