### PR TITLE
feat: 添加地理位置检查工具以优化资源下载源选择

### DIFF
--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -23,6 +23,7 @@ import java.util.concurrent.*;
 
 public class AssetUtil {
     private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
+    private static final String GITHUB = "https://raw.githubusercontent.com/";
     private static final List<String> MIRRORS;
 
     static {
@@ -54,7 +55,7 @@ public class AssetUtil {
             Log.info("Inside mainland China: Testing mirrors...");
         } else {
             // 海外用户：直接使用 GitHub 源
-            urls.add("https://raw.githubusercontent.com/");
+            urls.add(GITHUB);
             Log.info("Outside mainland China: Using GitHub source...");
         }
 

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -45,34 +45,38 @@ public class AssetUtil {
     }
 
     public static String getFastestUrl() {
-        List<String> urls = new ArrayList<>(MIRRORS);
-        urls.add(CFPA_ASSET_ROOT);
+        List<String> urls = new ArrayList<>();
+        
+        // 根据地理位置选择源列表
+        if (GeoLocationUtil.isMainlandChina()) {
+            // 中国大陆：测速选择最快的国内源
+            urls.addAll(MIRRORS);
+            urls.add(CFPA_ASSET_ROOT);
+            Log.info("Testing domestic mirror sources for mainland China user...");
+        } else {
+            // 海外用户：直接使用 GitHub 源
+            urls.add("https://raw.githubusercontent.com/");
+            Log.info("Using GitHub source for overseas user...");
+        }
 
         ExecutorService executor = Executors.newFixedThreadPool(Math.max(urls.size(), 10));
         try {
             List<CompletableFuture<String>> futures = new ArrayList<>();
             for (String url : urls) {
-                CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+                futures.add(CompletableFuture.supplyAsync(() -> {
                     try {
                         return testUrlConnection(url);
                     } catch (IOException e) {
-                        return null; // 表示失败
+                        return null;
                     }
-                }, executor);
-                futures.add(future);
+                }, executor));
             }
 
-            // 阻塞等待最快完成且成功的任务
             String fastest = null;
             while (!futures.isEmpty()) {
-                CompletableFuture<Object> first = CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0]));
-                fastest = (String) first.join();
-
-                // 移除已完成的 future
+                fastest = (String) CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0])).join();
                 futures.removeIf(CompletableFuture::isDone);
-
                 if (fastest != null) {
-                    // 成功，取消其他任务
                     for (CompletableFuture<String> f : futures) {
                         f.cancel(true);
                     }
@@ -81,8 +85,7 @@ public class AssetUtil {
                 }
             }
 
-            // 全部失败，返回默认 URL
-            Log.info("All urls are unreachable, using CFPA_ASSET_ROOT");
+            Log.info("All sources unreachable, using CFPA_ASSET_ROOT as fallback");
             return CFPA_ASSET_ROOT;
 
         } finally {

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -28,7 +28,6 @@ public class AssetUtil {
     static {
         // 镜像地址可以改成服务器下发
         MIRRORS = new ArrayList<>();
-        MIRRORS.add("https://raw.githubusercontent.com/");
         // 此镜像源维护者：502y
         MIRRORS.add("http://8.137.167.65:64684/");
     }

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.util.stream.Collectors;
 
 public class AssetUtil {
     private static final String CFPA_ASSET_ROOT = "http://downloader1.meitangdehulu.com:22943/";
@@ -45,51 +46,30 @@ public class AssetUtil {
     }
 
     public static String getFastestUrl() {
-        List<String> urls = new ArrayList<>();
-        
-        // 根据地理位置选择源列表
-        if (LocationDetectUtil.isMainlandChina()) {
-            // 中国大陆：测速选择最快的国内源
-            urls.addAll(MIRRORS);
-            urls.add(CFPA_ASSET_ROOT);
-            Log.info("Inside mainland China: Testing mirrors...");
-        } else {
-            // 海外用户：直接使用 GitHub 源
-            urls.add(GITHUB);
-            Log.info("Outside mainland China: Using GitHub source...");
+        // 海外用户直接用 GitHub，不测速
+        if (!LocationDetectUtil.isMainlandChina()) {
+            Log.info("Outside mainland China: Using GitHub source");
+            return GITHUB;
         }
 
-        ExecutorService executor = Executors.newFixedThreadPool(Math.max(urls.size(), 10));
+        // 中国大陆：测速选择最快的国内源
+        Log.info("Inside mainland China: Testing mirrors...");
+        List<String> urls = new ArrayList<>(MIRRORS);
+        urls.add(CFPA_ASSET_ROOT);
+
+        ExecutorService executor = Executors.newCachedThreadPool();
         try {
-            List<CompletableFuture<String>> futures = new ArrayList<>();
-            for (String url : urls) {
-                futures.add(CompletableFuture.supplyAsync(() -> {
-                    try {
-                        return testUrlConnection(url);
-                    } catch (IOException e) {
-                        return null;
-                    }
-                }, executor));
-            }
-
-            String fastest = null;
-            while (!futures.isEmpty()) {
-                fastest = (String) CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0])).join();
-                futures.removeIf(CompletableFuture::isDone);
-                if (fastest != null) {
-                    for (CompletableFuture<String> f : futures) {
-                        f.cancel(true);
-                    }
-                    Log.info("Using fastest url: %s", fastest);
-                    return fastest;
-                }
-            }
-
+            String fastest = executor.invokeAny(
+                urls.stream().map(url -> (Callable<String>) () -> testUrlConnection(url)).collect(Collectors.toList()),
+                10, TimeUnit.SECONDS
+            );
+            executor.shutdownNow();
+            Log.info("Using fastest url: %s", fastest);
+            return fastest;
+        } catch (Exception e) {
+            executor.shutdownNow();
             Log.info("All sources unreachable, using CFPA_ASSET_ROOT as fallback");
             return CFPA_ASSET_ROOT;
-
-        } finally {
-            executor.shutdownNow();
         }
     }
 

--- a/src/main/java/i18nupdatemod/util/AssetUtil.java
+++ b/src/main/java/i18nupdatemod/util/AssetUtil.java
@@ -48,15 +48,15 @@ public class AssetUtil {
         List<String> urls = new ArrayList<>();
         
         // 根据地理位置选择源列表
-        if (GeoLocationUtil.isMainlandChina()) {
+        if (LocationDetectUtil.isMainlandChina()) {
             // 中国大陆：测速选择最快的国内源
             urls.addAll(MIRRORS);
             urls.add(CFPA_ASSET_ROOT);
-            Log.info("Testing domestic mirror sources for mainland China user...");
+            Log.info("Inside mainland China: Testing mirrors...");
         } else {
             // 海外用户：直接使用 GitHub 源
             urls.add("https://raw.githubusercontent.com/");
-            Log.info("Using GitHub source for overseas user...");
+            Log.info("Outside mainland China: Using GitHub source...");
         }
 
         ExecutorService executor = Executors.newFixedThreadPool(Math.max(urls.size(), 10));

--- a/src/main/java/i18nupdatemod/util/GeoLocationUtil.java
+++ b/src/main/java/i18nupdatemod/util/GeoLocationUtil.java
@@ -1,0 +1,47 @@
+package i18nupdatemod.util;
+
+import org.apache.commons.io.IOUtils;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 地理位置检查工具 - 判断用户是否位于中国大陆
+ */
+public class GeoLocationUtil {
+    private static final String GEO_API_URL = "https://mips.kugou.com/check/iscn";
+    private static Boolean cached = null;
+
+    /**
+     * 检查用户是否位于中国大陆
+     */
+    public static boolean isMainlandChina() {
+        if (cached != null) {
+            return cached;
+        }
+
+        try {
+            HttpURLConnection conn = (HttpURLConnection) new URL(GEO_API_URL).openConnection();
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            int code = conn.getResponseCode();
+            
+            if (code == 200) {
+                String response = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8).trim();
+                cached = "1".equals(response) || "true".equalsIgnoreCase(response);
+                Log.info("Geo-location: " + (cached ? "mainland China" : "overseas"));
+                return cached;
+            }
+        } catch (Exception e) {
+            Log.debug("Geo-location check failed: " + e.getMessage());
+        }
+        
+        cached = false;
+        return false;
+    }
+
+    public static void resetCache() {
+        cached = null;
+    }
+}

--- a/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
+++ b/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
@@ -5,34 +5,67 @@ import org.apache.commons.io.IOUtils;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 public class LocationDetectUtil {
-    private static final String GEO_API_URL = "https://mips.kugou.com/check/iscn";
     private static Boolean cached = null;
+
+    private static final List<GeoApi> GEO_APIS = Arrays.asList(
+            new GeoApi("Kugou", "https://mips.kugou.com/check/iscn", 
+                    response -> "1".equals(response.trim()) || "true".equalsIgnoreCase(response.trim())),
+            new GeoApi("IP.SB", "https://api.ip.sb/geoip",
+                    response -> response.contains("\"country_code\":\"CN\"") || response.contains("\"country_code\": \"CN\""))
+    );
 
     public static boolean isMainlandChina() {
         if (cached != null) {
             return cached;
         }
 
+        for (GeoApi api : GEO_APIS) {
+            Boolean result = tryApi(api);
+            if (result != null) {
+                cached = result;
+                return cached;
+            }
+        }
+        
+        // 所有 API 都失败，默认为 false
+        cached = false;
+        return false;
+    }
+
+    private static Boolean tryApi(GeoApi api) {
         try {
-            HttpURLConnection conn = (HttpURLConnection) new URL(GEO_API_URL).openConnection();
+            HttpURLConnection conn = (HttpURLConnection) new URL(api.url).openConnection();
             conn.setConnectTimeout(5000);
             conn.setReadTimeout(5000);
             int code = conn.getResponseCode();
             
             if (code == 200) {
-                String response = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8).trim();
-                cached = "1".equals(response) || "true".equalsIgnoreCase(response);
-                Log.info("Location Detected: " + (cached ? "Inside mainland China" : "Outside mainland China"));
-                return cached;
+                String response = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+                boolean isChina = api.parser.test(response);
+                Log.info("Location Detected (" + api.name + " API): " + (isChina ? "Inside mainland China" : "Outside mainland China"));
+                return isChina;
             }
         } catch (Exception e) {
-            Log.debug("Location detection failed: " + e.getMessage());
+            Log.debug(api.name + " API detection failed: " + e.getMessage());
         }
-        
-        cached = false;
-        return false;
+        return null;
+    }
+
+    private static class GeoApi {
+        final String name;
+        final String url;
+        final Predicate<String> parser;
+
+        GeoApi(String name, String url, Predicate<String> parser) {
+            this.name = name;
+            this.url = url;
+            this.parser = parser;
+        }
     }
 
     public static void resetCache() {

--- a/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
+++ b/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
@@ -10,7 +10,7 @@ public class LocationDetectUtil {
     private static Boolean cached = null;
     
     private static final String[][] GEO_APIS = {
-            {"Kugou", "https://mips.kugou.com/check/iscn"},
+            {"Kugou", "https://mips.kugou.com/check/iscn?&format=json"},
             {"IP.SB", "https://api.ip.sb/geoip"}
     };
 
@@ -51,11 +51,11 @@ public class LocationDetectUtil {
 
     private static boolean parseResponse(String response) {
         response = response.trim();
-        // Kugou API 返回 "1" 或 "true"
-        if ("1".equals(response) || "true".equalsIgnoreCase(response)) {
+        // Kugou API JSON: {"flag": 1} 或 {"flag": true}
+        if (response.contains("\"flag\":1") || response.contains("\"flag\": 1") ||response.contains("\"flag\":true") || response.contains("\"flag\": true")) {
             return true;
         }
-        // IP.SB API 返回 JSON，检查 country_code
+        // IP.SB API JSON: {"country_code": "CN"}
         if (response.contains("\"country_code\":\"CN\"") || response.contains("\"country_code\": \"CN\"")) {
             return true;
         }

--- a/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
+++ b/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
@@ -5,67 +5,61 @@ import org.apache.commons.io.IOUtils;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Predicate;
 
 public class LocationDetectUtil {
     private static Boolean cached = null;
-
-    private static final List<GeoApi> GEO_APIS = Arrays.asList(
-            new GeoApi("Kugou", "https://mips.kugou.com/check/iscn", 
-                    response -> "1".equals(response.trim()) || "true".equalsIgnoreCase(response.trim())),
-            new GeoApi("IP.SB", "https://api.ip.sb/geoip",
-                    response -> response.contains("\"country_code\":\"CN\"") || response.contains("\"country_code\": \"CN\""))
-    );
+    
+    private static final String[][] GEO_APIS = {
+            {"Kugou", "https://mips.kugou.com/check/iscn"},
+            {"IP.SB", "https://api.ip.sb/geoip"}
+    };
 
     public static boolean isMainlandChina() {
         if (cached != null) {
             return cached;
         }
 
-        for (GeoApi api : GEO_APIS) {
-            Boolean result = tryApi(api);
+        for (String[] api : GEO_APIS) {
+            Boolean result = tryApi(api[0], api[1]);
             if (result != null) {
                 cached = result;
                 return cached;
             }
         }
         
-        // 所有 API 都失败，默认为 false
         cached = false;
         return false;
     }
 
-    private static Boolean tryApi(GeoApi api) {
+    private static Boolean tryApi(String name, String url) {
         try {
-            HttpURLConnection conn = (HttpURLConnection) new URL(api.url).openConnection();
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
             conn.setConnectTimeout(5000);
             conn.setReadTimeout(5000);
-            int code = conn.getResponseCode();
             
-            if (code == 200) {
+            if (conn.getResponseCode() == 200) {
                 String response = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
-                boolean isChina = api.parser.test(response);
-                Log.info("Location Detected (" + api.name + " API): " + (isChina ? "Inside mainland China" : "Outside mainland China"));
+                boolean isChina = parseResponse(response);
+                Log.info("Location Detected (" + name + " API): " + (isChina ? "Inside mainland China" : "Outside mainland China"));
                 return isChina;
             }
         } catch (Exception e) {
-            Log.debug(api.name + " API detection failed: " + e.getMessage());
+            Log.debug(name + " API detection failed: " + e.getMessage());
         }
         return null;
     }
 
-    private static class GeoApi {
-        final String name;
-        final String url;
-        final Predicate<String> parser;
-
-        GeoApi(String name, String url, Predicate<String> parser) {
-            this.name = name;
-            this.url = url;
-            this.parser = parser;
+    private static boolean parseResponse(String response) {
+        response = response.trim();
+        // Kugou API 返回 "1" 或 "true"
+        if ("1".equals(response) || "true".equalsIgnoreCase(response)) {
+            return true;
         }
+        // IP.SB API 返回 JSON，检查 country_code
+        if (response.contains("\"country_code\":\"CN\"") || response.contains("\"country_code\": \"CN\"")) {
+            return true;
+        }
+        return false;
     }
 
     public static void resetCache() {

--- a/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
+++ b/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * 地理位置检查工具 - 判断用户是否位于中国大陆
  */
-public class GeoLocationUtil {
+public class LocationDetectUtil {
     private static final String GEO_API_URL = "https://mips.kugou.com/check/iscn";
     private static Boolean cached = null;
 

--- a/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
+++ b/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
@@ -51,18 +51,7 @@ public class LocationDetectUtil {
 
     private static boolean parseResponse(String response) {
         response = response.trim();
-        // Kugou API JSON: {"flag": 1} 或 {"flag": true}
-        if (response.contains("\"flag\":1") || response.contains("\"flag\": 1") ||response.contains("\"flag\":true") || response.contains("\"flag\": true")) {
-            return true;
-        }
-        // IP.SB API JSON: {"country_code": "CN"}
-        if (response.contains("\"country_code\":\"CN\"") || response.contains("\"country_code\": \"CN\"")) {
-            return true;
-        }
-        return false;
-    }
-
-    public static void resetCache() {
-        cached = null;
+        // Kugou: {"flag":1/true} | IP.SB: {"country_code":"CN"}
+        return response.matches(".*(\"flag\".*[\":] *(1|true)|\"country_code\".*\"CN\").*");
     }
 }

--- a/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
+++ b/src/main/java/i18nupdatemod/util/LocationDetectUtil.java
@@ -6,16 +6,10 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-/**
- * 地理位置检查工具 - 判断用户是否位于中国大陆
- */
 public class LocationDetectUtil {
     private static final String GEO_API_URL = "https://mips.kugou.com/check/iscn";
     private static Boolean cached = null;
 
-    /**
-     * 检查用户是否位于中国大陆
-     */
     public static boolean isMainlandChina() {
         if (cached != null) {
             return cached;
@@ -30,11 +24,11 @@ public class LocationDetectUtil {
             if (code == 200) {
                 String response = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8).trim();
                 cached = "1".equals(response) || "true".equalsIgnoreCase(response);
-                Log.info("Geo-location: " + (cached ? "mainland China" : "overseas"));
+                Log.info("Location Detected: " + (cached ? "Inside mainland China" : "Outside mainland China"));
                 return cached;
             }
         } catch (Exception e) {
-            Log.debug("Geo-location check failed: " + e.getMessage());
+            Log.debug("Location detection failed: " + e.getMessage());
         }
         
         cached = false;


### PR DESCRIPTION
# What's Changed:
1. 添加地理位置检测
2. 将 Github 移出镜像列表
3. 根据检测到的地理位置选择下载源

## 具体思路：
```mermaid
graph TD
    A[检测地理位置] --> B[中国大陆]
    A --> C[非中国大陆]
    B --> D[葫芦]
    B --> E[镜像源]
    D --> F[测速]
    E --> F[测速]
    F --> G[选择最快的]
    C --> H[直接使用 Github]
    G --> I[下载]
    H --> I[下载]

```

---
由 AI 修改，并在本地测试
resolve #59 

<details><summary>Copilot's Summary</summary>
This pull request introduces geographic-based source selection for asset downloads by detecting if the user is in mainland China and adjusting the asset mirror list accordingly. It adds a new utility class for location detection, updates the mirror selection logic, and improves logging and fallback behavior.

**Geographic source selection and location detection:**

* Added a new `LocationDetectUtil` class to determine if the user is in mainland China using external geo-IP APIs, with result caching and fallback logic. (`src/main/java/i18nupdatemod/util/LocationDetectUtil.java`)
* Updated `AssetUtil.getFastestUrl()` to use `LocationDetectUtil.isMainlandChina()` to select different asset sources: domestic mirrors and the legacy root for users in China, or GitHub for users elsewhere. (`src/main/java/i18nupdatemod/util/AssetUtil.java`)

**Mirror management and logging:**

* Removed GitHub from the default `MIRRORS` list and instead added it as a separate constant, only used for overseas users. (`src/main/java/i18nupdatemod/util/AssetUtil.java`)
* Enhanced logging in `getFastestUrl()` to indicate which source list is being used and to clarify fallback behavior when all sources fail. (`src/main/java/i18nupdatemod/util/AssetUtil.java`) [[1]](diffhunk://#diff-ef87f37b35bb805bfc358ba5a1c0e4eb673ca7fd340119b4caa62588546688caL48-L75) [[2]](diffhunk://#diff-ef87f37b35bb805bfc358ba5a1c0e4eb673ca7fd340119b4caa62588546688caL84-R88)
</details>